### PR TITLE
Removed extra turn_on call after set_speed

### DIFF
--- a/dist/fan-control-entity-row.js
+++ b/dist/fan-control-entity-row.js
@@ -206,7 +206,6 @@ class CustomFanRow extends Polymer.Element {
 		this.hass.callService('fan', 'turn_off', {entity_id: this._config.entity});
 	} else {
 		this.hass.callService('fan', 'set_speed', {entity_id: this._config.entity, speed: speed});
-		this.hass.callService('fan', 'turn_on', {entity_id: this._config.entity});
 	}
     }
 


### PR DESCRIPTION
Fixes #2 and should stop reverting the speed for some integrations (like Lutron)