### PR TITLE
Off command being sent with speed command. Causing BOND fan to not turn off correctly

### DIFF
--- a/dist/fan-control-entity-row.js
+++ b/dist/fan-control-entity-row.js
@@ -90,6 +90,7 @@ class CustomFanRow extends Polymer.Element {
 			customTheme: false,
 			sendStateWithSpeed: false,
 			reverseButtons: false,
+			sendSpeedWithOff: true,
 			isOffColor: '#f44c09',
 			isOnLowColor: '#43A047',
 			isOnMedColor: '#43A047',
@@ -109,6 +110,7 @@ class CustomFanRow extends Polymer.Element {
 		const stateObj = hass.states[config.entity];
 		const custTheme = config.customTheme;
 		const sendStateWithSpeed = config.sendStateWithSpeed;
+		const sendSpeedWithOff = config.sendSpeedWithOff;
 		const revButtons = config.reverseButtons;
 		const custOnLowClr = config.isOnLowColor;
 		const custOnMedClr = config.isOnMedColor;
@@ -261,7 +263,9 @@ class CustomFanRow extends Polymer.Element {
 		const speed = e.currentTarget.getAttribute('name');
 		if( speed == 'off' ){
 			this.hass.callService('fan', 'turn_off', {entity_id: this._config.entity});
-			this.hass.callService('fan', 'set_speed', {entity_id: this._config.entity, speed: speed});
+			if(this._config.sendSpeedWithOff){
+				this.hass.callService('fan', 'set_speed', {entity_id: this._config.entity, speed: speed});
+			}
 		} else {
 			if(this._config.sendStateWithSpeed){
 			this.hass.callService('fan', 'turn_on', {entity_id: this._config.entity});

--- a/readme.md
+++ b/readme.md
@@ -33,10 +33,12 @@ Then to use this in a card place the following in your entity card:
 | name | String | No | none | A custom name for the entity in the row |
 | customTheme | Boolean | No | false | set to true to use a custom theme |
 | sendStateWithSpeed | Boolean | No | false | Used only for certain firmware that requires the State command be sent with the Speed command  |
+| sendSpeedWithOff | Boolean | No | true | Used only for certain firmware that requires the off command be sent without the Speed command  |
 | isOffColor | String | No | '#f44c09' | Sets the color of the 'Off' button if fan is off |
 | isOnLowColor | String | No | '#43A047' | Sets the color of the 'Low' button if fan is on low |
 | isOnMedColor | String | No | '#43A047' | Sets the color of the 'Med' button if fan is on Medium |
 | isOnHiColor | String | No | '#43A047' | Sets the color of the 'Hi' button if fan is on high |
+
 | buttonInactiveColor | String | No | '#759aaa' | Sets the color of the the buttons if that selection is off |
 | customOffText | String | No | 'OFF' | Sets the text of the "off" button |
 | customLowText | String | No | 'LOW' | Sets the text of the "low" speed button |


### PR DESCRIPTION
I propose adding the command "sendSpeedWithOff" to disable the sending of fan.set_speed along with fan.turn_off. This caused an issue with that particular integration and it may help others with other types of fans.
My PR creates no breaking changes and leaves the original code to function as it had previously.
I have also included an update to the README.MD.